### PR TITLE
Fix usage of Roboto font

### DIFF
--- a/assets/css/common.css
+++ b/assets/css/common.css
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 body {
-  font-family: "Roboto";
+  font-family: "Roboto", sans-serif;
   padding: 0;
   margin: 0;
 }

--- a/blog/index.html
+++ b/blog/index.html
@@ -38,6 +38,9 @@
     <title>Service Weaver Blog</title>
     <link rel="stylesheet" href="/assets/css/common.css">
     <link rel="stylesheet" href="/assets/css/blog.css">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Roboto&display=swap" rel="stylesheet">
   </head>
   <body>
     

--- a/blog/quick_intro.html
+++ b/blog/quick_intro.html
@@ -38,6 +38,9 @@
     <title>A Quick Introduction to Service Weaver</title>
     <link rel="stylesheet" href="/assets/css/common.css">
     <link rel="stylesheet" href="/assets/css/blog.css">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Roboto&display=swap" rel="stylesheet">
   </head>
   <body>
     

--- a/contact.html
+++ b/contact.html
@@ -38,6 +38,9 @@
   <title></title>
   <link rel="stylesheet" href="/assets/css/common.css">
   <link rel="stylesheet" href="/assets/css/blog.css">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Roboto&display=swap" rel="stylesheet">
 </head>
 <body>
 

--- a/docs.html
+++ b/docs.html
@@ -39,6 +39,9 @@
     <title>Service Weaver Docs</title>
     <link rel="stylesheet" href="/assets/css/common.css">
     <link rel="stylesheet" href="/assets/css/docs.css">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Roboto&display=swap" rel="stylesheet">
   </head>
   <body>
     

--- a/index.html
+++ b/index.html
@@ -38,6 +38,9 @@
     <title>Service Weaver</title>
     <link rel="stylesheet" href="/assets/css/common.css">
     <link rel="stylesheet" href="/assets/css/home.css">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Roboto&display=swap" rel="stylesheet">
   </head>
   <body>
     


### PR DESCRIPTION
I noticed that this website uses the Roboto font without importing it as a web font. This causes it to show up as the default serif font on my system. To remedy this, I've added the code from https://fonts.google.com/specimen/Roboto to import the web font, and I've also modified the CSS to have a sans-serif fallback in case the font fails to load.